### PR TITLE
fix: use correct npm token secret name (NPM_READ_WRITE)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Publish to npm
         run: npm publish --provenance
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_READ_WRITE }}
 
       - name: Create GitHub Release Archive
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Description

Fixed the npm publish workflow to use the correct secret name `NPM_READ_WRITE` instead of `NPM_TOKEN`.

## Changes
- Updated .github/workflows/publish.yml to use secrets.NPM_READ_WRITE

## Why
The GitHub secret for npm authentication is named `NPM_READ_WRITE`, but the workflow was looking for `NPM_TOKEN`.