### PR TITLE
fix: use NPM_READ_WRITE secret for npm publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Publish to npm
         run: npm publish --provenance --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.github-token }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_READ_WRITE }}
 
       - name: Create GitHub Release Archive
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Update workflow to use NPM_READ_WRITE secret instead of non-existent github-token