### PR TITLE
release: 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [1.5.0] - 2026-02-02
+
 ### Changed
 - Refactored output formatting helpers in `src/index.ts` for clearer model/tool usage rendering.
 - Consolidated repeated error-detail formatting logic in `src/api/client.ts`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-glm-quota",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "type": "module",
   "description": "OpenCode plugin to query Z.ai GLM Coding Plan usage statistics including quota limits, model usage, and MCP tool usage",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- bump version to 1.5.0
- move Unreleased notes into 1.5.0 changelog entry

## Testing
- Not run (release notes update only)