### PR TITLE
chore(release): bump version to 1.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [1.6.3] - 2026-03-30
+
+### Fixed
+- **minimatch ReDoS vulnerabilities** - Added `minimatch` override (`^9.0.7`) in `package.json` to resolve HIGH severity Dependabot alerts (#7, #9)
+  - `matchOne()` combinatorial backtracking via multiple non-adjacent GLOBSTAR segments
+  - Affected transitive dev dependencies: `typescript-eslint`, `eslint`, `c8/test-exclude`
+
+### Technical
+- Added `"overrides": { "minimatch": "^9.0.7" }` to `package.json`
+- Updated `sonar-project.properties` version from outdated `1.2.0` to `1.6.3`
+- Updated wiki pages (Home, Quick-Reference, API-Documentation, Development-and-Contributing) with current test counts and version info
+- `npm audit` now reports **0 vulnerabilities** (was 6 high)
+
 ## [1.6.2] - 2026-03-22
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-glm-quota",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-glm-quota",
-      "version": "1.6.2",
+      "version": "1.6.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-glm-quota",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "type": "module",
   "description": "OpenCode plugin to query Z.ai GLM Coding Plan usage statistics including quota limits, model usage, and MCP tool usage",
   "main": "dist/index.js",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -8,7 +8,7 @@ sonar.host.url=https://sonarcloud.io
 
 # Project metadata
 sonar.projectName=OpenCode GLM Quota Plugin
-sonar.projectVersion=1.2.0
+sonar.projectVersion=1.6.3
 
 # Source code configuration
 sonar.sources=src


### PR DESCRIPTION
## Summary

- Bump version from 1.6.2 to 1.6.3
- Update `sonar-project.properties` version from outdated `1.2.0` to `1.6.3`
- Add CHANGELOG entry for 1.6.3

## Changes

- **package.json**: Version `1.6.2` → `1.6.3`
- **package-lock.json**: Updated lockfile
- **sonar-project.properties**: `sonar.projectVersion=1.2.0` → `1.6.3`
- **CHANGELOG.md**: Added 1.6.3 release notes (minimatch ReDoS security fix, docs sync)

## Wiki Updates (pushed directly)

- **Home.md**: Added v1.6.1, v1.6.2, v1.6.3 release sections
- **Quick-Reference.md**: Fixed weekly quota mention, output example alignment, header description
- **API-Documentation.md**: Fixed stale "January 2025" → "January 2026"
- **Development-and-Contributing.md**: Updated test count 89 → 110

## Testing

- ✅ `npm run build` — TypeScript compiles
- ✅ `npm run lint` — No issues
- ✅ `npm test` — 110/110 tests pass
- ✅ `npm audit` — 0 vulnerabilities