### PR TITLE
chore(release): 1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [1.8.1] - 2026-07-12
+
 ### Fixed
 - **Windows credentials lookup resolves cross-platform auth path** - On Windows the plugin only checked `%LOCALAPPDATA%\opencode\auth.json`, but opencode stores `auth.json` at the XDG-compatible path `~/.local/share/opencode/auth.json` on ALL platforms (including Windows). The plugin now probes every candidate location (legacy LOCALAPPDATA first for back-compat, then the XDG path) and tries each one until valid credentials are found, so a stale or partial file at one location no longer masks valid credentials at another. Authenticated Windows users are no longer incorrectly reported as "Credentials Not Found" (Issues #39, #41).
 

--- a/README.md
+++ b/README.md
@@ -217,6 +217,8 @@ The plugin discovers credentials in this order:
 1. **OpenCode authentication context** (managed by OpenCode) - PRIMARY
 2. **Environment variable** `ZAI_API_KEY` (Global) or `ZHIPU_API_KEY` (CN) - FALLBACK (dev/testing only)
 
+**Where credentials are read:** OpenCode stores `auth.json` at `~/.local/share/opencode/auth.json` on **all platforms, including Windows**. On Windows the plugin additionally checks the legacy `%LOCALAPPDATA%\opencode\auth.json` location as a fallback, trying the XDG path first so a stale legacy or workaround copy can never override current credentials. Every candidate is probed until one yields a valid key.
+
 ### Time Window
 
 Usage statistics are queried for a 24-hour rolling window:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-glm-quota",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "type": "module",
   "description": "OpenCode plugin to query Z.ai GLM Coding Plan usage statistics including quota limits, model usage, and MCP tool usage",
   "main": "dist/index.js",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -8,7 +8,7 @@ sonar.host.url=https://sonarcloud.io
 
 # Project metadata
 sonar.projectName=OpenCode GLM Quota Plugin
-sonar.projectVersion=1.8.0
+sonar.projectVersion=1.8.1
 
 # Source code configuration
 sonar.sources=src


### PR DESCRIPTION
Version bump + doc/changelog/sonar updates for the 1.8.1 release shipping the Windows auth.json path fix (#39/#41, #42).

- `package.json` 1.8.0 → 1.8.1
- `sonar-project.properties` projectVersion → 1.8.1
- `CHANGELOG.md` [Unreleased] Fixed → [1.8.1] - 2026-07-12
- `README.md` Credential Priority: document XDG-first + Windows legacy fallback

Post-merge: tag v1.8.1 + GitHub Release (triggers npm + GitHub Packages publish).